### PR TITLE
feat: implement unique IDs strategy with Drizzle ORM

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fastify": "^5.4.0",
     "fastify-type-provider-zod": "^5.0.3",
     "postgres": "^3.4.7",
+    "uuidv7": "^1.0.2",
     "zod": "^4.0.16"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       postgres:
         specifier: ^3.4.7
         version: 3.4.7
+      uuidv7:
+        specifier: ^1.0.2
+        version: 1.0.2
       zod:
         specifier: ^4.0.16
         version: 4.0.16
@@ -1240,6 +1243,10 @@ packages:
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
+  uuidv7@1.0.2:
+    resolution: {integrity: sha512-8JQkH4ooXnm1JCIhqTMbtmdnYEn6oKukBxHn1Ic9878jMkL7daTI7anTExfY18VRCX7tcdn5quzvCb6EWrR8PA==}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -2282,6 +2289,8 @@ snapshots:
   typescript@5.9.2: {}
 
   undici-types@7.10.0: {}
+
+  uuidv7@1.0.2: {}
 
   vite-node@3.2.4(@types/node@24.2.1)(tsx@4.20.3)(yaml@2.8.1):
     dependencies:

--- a/src/infra/db/index.ts
+++ b/src/infra/db/index.ts
@@ -1,0 +1,7 @@
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { env } from "@/env";
+import { schema } from "./schemas";
+
+export const pg = postgres(env.DATABASE_URL);
+export const db = drizzle(pg, { schema });

--- a/src/infra/db/schemas/index.ts
+++ b/src/infra/db/schemas/index.ts
@@ -1,0 +1,5 @@
+import { uploads } from "./uploads";
+
+export const schema = {
+  uploads,
+};

--- a/src/infra/db/schemas/uploads.ts
+++ b/src/infra/db/schemas/uploads.ts
@@ -1,10 +1,10 @@
-import { randomUUID } from "node:crypto";
+import { uuidv7 } from "uuidv7";
 import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 export const uploads = pgTable("uploads", {
   id: text("id")
     .primaryKey()
-    .$defaultFn(() => randomUUID()),
+    .$defaultFn(() => uuidv7()),
   name: text("name").notNull(),
   remoteKey: text("remote_key").notNull().unique(),
   remoteUrl: text("remote_url").notNull(),

--- a/src/infra/http/routes/upload-image.ts
+++ b/src/infra/http/routes/upload-image.ts
@@ -1,5 +1,7 @@
 import type { FastifyPluginAsyncZod } from "fastify-type-provider-zod";
 import { z } from "zod";
+import { schema } from "@/infra/db/schemas";
+import { db } from "@/infra/db";
 
 export const uploadImageRoute: FastifyPluginAsyncZod = async (server) => {
   server.post(
@@ -20,6 +22,12 @@ export const uploadImageRoute: FastifyPluginAsyncZod = async (server) => {
       },
     },
     async (request, reply) => {
+      await db.insert(schema.uploads).values({
+        name: "teste.jpg",
+        remoteKey: "teste.jpg",
+        remoteUrl: "http://asdasd.com",
+      });
+
       return reply.status(201).send({ uploadId: "test" });
     }
   );


### PR DESCRIPTION
## 🗄️ **Unique IDs Strategy Implementation / Implementação da Estratégia de IDs Únicos**

### **���� PORTUGUÊS:**
- ✅ Estrutura de banco com arquivos index.ts
- ✅ Schema uploads sem defaults de UUID
- ✅ Rota upload-image configurada para inserir dados
- ✅ Demonstração de geração de UUID pelo código da aplicação
- ✅ Teste de integração com Swagger e Drizzle Studio

### **🇺🇸 ENGLISH:**
- ✅ Database structure with index.ts files
- ✅ Uploads schema without UUID defaults
- ✅ Upload-image route configured to insert data
- ✅ Demonstration of UUID generation by application code
- ✅ Integration testing with Swagger and Drizzle Studio

---

## Referência à Issue
Closes #6